### PR TITLE
Auto Training Updates (Sunday @ 17z)

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -7,6 +7,7 @@ use App\Jobs\ProcessSessionLogging;
 use App\Jobs\ProcessSessionReminders;
 use App\Jobs\ProcessSoloCertExpiryWarnings;
 use App\Jobs\ProcessShanwickController;
+use App\Jobs\DiscordTrainingUpdates;
 use App\Models\Roster\RosterMember;
 use App\Notifications\Network\OneWeekInactivityReminder;
 use App\Notifications\Network\TwoWeekInactivityReminder;
@@ -103,6 +104,9 @@ class Kernel extends ConsoleKernel
 
         //Training/OTS session reminders
         $schedule->job(new ProcessSessionReminders())->daily();
+
+        // Check Training Threads Status (Once per week)
+        $schedule->job(new DiscordTrainingUpdates())->weeklyOn(7, '17:00');
 
         // Discord role updating
         //$schedule->job(new UpdateDiscordUserRoles)->twiceDaily(6, 18);

--- a/app/Http/Controllers/DiscordTestController.php
+++ b/app/Http/Controllers/DiscordTestController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Services\DiscordClient;
-use App\Jobs\ProcessShanwickController;
+use App\Jobs\DiscordTrainingUpdates;
 
 class DiscordTestController extends Controller
 {
@@ -26,7 +26,7 @@ class DiscordTestController extends Controller
     public function Shanwick()
     {
         // Dispatch the job
-        $job = ProcessShanwickController::dispatch();
+        $job = DiscordTrainingUpdates::dispatch();
 
         // Call the handle method directly to get the result synchronously
         $result = $job->handle();

--- a/app/Http/Controllers/Training/ApplicationsController.php
+++ b/app/Http/Controllers/Training/ApplicationsController.php
@@ -144,7 +144,7 @@ class ApplicationsController extends Controller
         $discord = new DiscordClient();
         $discord->sendMessageWithEmbed(config('app.env') == 'local' ? intval(config('services.discord.web_logs')) : intval(config('services.discord.applications')), 'New Training Applicant!', $application->user->fullName('FLC').' has just applied to control at Gander Oceanic!
         
-        [View their application now](https://ganderoceanic.ca/admin/training/applications/'.$application->reference_id.')');
+[View their application now](https://ganderoceanic.ca/admin/training/applications/'.$application->reference_id.')');
 
         //Redirect to application page
         return redirect()->route('training.applications.show', $application->reference_id);

--- a/app/Jobs/DiscordTrainingUpdates.php
+++ b/app/Jobs/DiscordTrainingUpdates.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+use GuzzleHttp\Client;
+use App\Services\DiscordClient;
+use App\Models\Training\Instructing\Records\TrainingSession;
+use App\Models\Training\Instructing\Students\Student;
+use App\Notifications\Training\Instructing\RemovedAsStudent;
+use App\Models\Training\Instructing\Students\StudentStatusLabel;
+use App\Models\Training\Instructing\Links\StudentStatusLabelLink;
+use Carbon\Carbon;
+
+class DiscordTrainingUpdates implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        // Function for Training Thread Availability Updates
+        {
+            // Initialize the DiscordClient inside the handle method
+            $discord = new DiscordClient();
+
+            // Number of Messages Sent
+            $counter = 0;
+
+            // Get Active Threads
+            $response = $discord->getClient()->get('guilds/'.env('DISCORD_GUILD_ID').'/threads/active');
+            $results = json_decode($response->getBody(), true);
+
+            foreach ($results['threads'] as $thread) {
+
+                // Get the ID of the Active Training Thread
+                if (preg_match('/\d+$/', $thread['name'], $matches)) {
+                    $cid = $matches[0];
+                } else {
+                    $cid = null;
+                }
+
+                // Check Lable is 'In Progress' or 'Ready For Pick-Up'
+
+                // Check Sessions Upcoming
+                $student = Student::where('user_id', $cid)->first();
+                $upcoming_sessions = TrainingSession::where('student_id', $student->id)->whereBetween('scheduled_time', [Carbon::now(), Carbon::now()->addDays(7)])->first();
+                
+                if($upcoming_sessions == null){
+                    // There is no sessions within the next week
+                    $counter++; //Add 1 to the $counter variable
+
+                    // SendEmbed to ask student to send availability
+                    $discord->sendEmbedInTrainingThread($cid, "Your Availability", 'Hello, <@'.$student->user->discord_user_id.'>
+
+Please provide your availability for the next 7-14 days. Please ensure to tag the `@Instructor` role with all times you are available. Please provide these times in Zulu Format.
+
+One of our team will make contact with you to organise a session if they have availability matching yours.
+
+*If you have done this in the past few days, please disregard this message.*');
+                }
+            }
+
+            // Tell the log chat
+            $discord->sendMessageWithEmbed(env('DISCORD_WEB_LOGS'), 'AUTO: Training Thread Availability Requests',$counter. ' Training Threads have been messaged asking for their weekly availability. This is only completed if a student has no scheduled session within the next 7 days.');
+        }
+
+        // Check 'Awaiting Exam' label students between 31-37 Days after Application
+        {
+            $count = 0;
+            
+            $student = Student::whereBetween('created_at', [Carbon::now()->subDays(37), Carbon::now()->subDays(30)])->where('current', true)->get();
+
+            foreach($student as $s){
+                if ($s->hasLabel('Awaiting Exam')) {
+                    // Add one to the count
+                    $count++;
+                    // SendEmbed to ask student to send availability
+                    $discord->sendEmbedInTrainingThread($cid, "Exam Not Requested", 'Hello, <@'.$s->user->discord_user_id.'>
+
+Our records indicate that you have not requested, or completed your exam within a month of your Application being approved.
+
+Please read the above message in order to understand how to request the exam.
+
+Should you not request, and pass the exam within 60 days of your application being accepted, your training will be automatically terminated, and you will need to reapply to begin your training once more.
+
+**Kind Regards,
+Gander Oceanic Training Team**');
+                }
+            }
+
+            // Tell the log chat
+            $discord->sendMessageWithEmbed(env('DISCORD_WEB_LOGS'), 'AUTO: Training Thread Exam Requests Reminder',$count. ' Students are between 30-37 days past application without completing the exam. They have been notified of this.');
+        }
+
+
+        // Check 'Awaiting-Exam' label students 60 Days after Application and Terminate Training Automatically
+        {
+            $count2 = 0;
+
+            $student = Student::where('created_at', '<=', Carbon::now()->subDays(60))->where('current', true)->get();
+
+            foreach($student as $s){
+                if ($s->hasLabel('Awaiting Exam')) {
+                    // Add one to the count
+                    $count2++;
+
+                    // dd($s);
+
+                    //Make as not current
+                    $s->current = false;
+
+                    //Remove role
+                    $s->user->removeRole('Student');
+
+                    //Discord Updates
+                    if ($s->user->hasDiscord() && $s->user->member_of_czqo) {
+                        //Get Discord client
+                        $discord = new DiscordClient();
+
+                        //remove student discord role
+                        $discord->removeRole($s->user->discord_user_id, 482824058141016075);
+
+                        $discord->EditThreadTag('Inactive', $s->user->id);
+
+                        //close training Thread
+                        $discord->closeTrainingThread($s->user->id, $s->user->discord_user_id, 'terminate');
+
+                        // Notify Senior Team that new training has been terminated.
+                        $discord->sendMessageWithEmbed(config('app.env') == 'local' ? intval(config('services.discord.web_logs')) : intval(config('services.discord.instructors')), 'Training Terminated', $s->user->fullName('FLC').' has had their training terminated. `Exam not completed within 60 days.`', 'error');
+                    
+                    } else {
+                        //Get Discord client
+                        $discord = new DiscordClient();
+                        
+                        // Notify Senior Team that training has been terminated
+                        $discord->sendMessageWithEmbed(config('app.env') == 'local' ? intval(config('services.discord.web_logs')) : intval(config('services.discord.instructors')), 'Training Terminated', $s->user->fullName('FLC').' has had their training terminated. `Exam not completed within 60 days.`', 'error');
+                    }
+
+                    foreach ($s->labels as $label) {
+                        if (!in_array($label->label()->name, ['inactive'])) {
+                            $label->delete();
+                        }
+                    }
+
+                    //Remove labels and instructor links and availability
+                    $label = new StudentStatusLabelLink([
+                        'student_status_label_id' => StudentStatusLabel::whereName('Inactive')->first()->id,
+                        'student_id'              => $s->id,
+                    ]);
+                    $label->save();
+                    
+
+                    if ($s->instructor()) {
+                        $s->instructor()->delete();
+                    }
+                    foreach ($s->availability as $a) {
+                        $a->delete();
+                    }
+
+                    //notify
+                    $s->user->notify(new RemovedAsStudent());
+
+                    //Save
+                    $s->save();
+                }
+            }
+
+            // Tell the log chat
+            $discord->sendMessageWithEmbed(env('DISCORD_WEB_LOGS'), 'AUTO: Training Termination',$count2. ' Students have been terminated automatically. Exam not completed within 60 days.');
+
+        }
+    }
+}

--- a/app/Services/DiscordClient.php
+++ b/app/Services/DiscordClient.php
@@ -22,6 +22,11 @@ class DiscordClient
         ]);
     }
 
+    // Get Discord Client (For external use outside of this php file)
+    public function getClient() {
+        return $this->client;
+    }
+
     public function sendMessage($channelId, $message)
     {
         $response = $this->client->post("channels/{$channelId}/messages", [
@@ -132,16 +137,34 @@ Good luck with your study!',
                     $this->sendMessageWithEmbed($thread['id'], 'Oceanic Training Completed!',
 'Congratulations <@'.$discord_id.'>, you have now been certified on Gander & Shanwick Oceanic!
                 
-This training thread will now be closed due to the completion of your training. Your discord roles will automatically be updated within the next 24 Hours.
+This training thread will now be closed due to the completion of your training. Your discord roles will automatically be updated within the next 24
 
 If you have any questions, please reach out to your Instructor, or ask your question in <#836707337829089322>.
 
-Enjoy controlling Gander & Shanwick OCA!');
+Enjoy controlling Gander & Shanwick OCA!
+
+**Kind Regards,
+Gander Oceanic Training Team**');
+
                 } elseif($status == "cancel") {
                     $this->sendMessageWithEmbed($thread['id'], 'Oceanic Training Cancelled',
-'<@'.$discord_id.'>, Your training request with Gander Oceanic has been terminated on <t:'.Carbon::now()->timestamp.':F>
+'<@'.$discord_id.'>, Your training request with Gander Oceanic has been terminated at <t:'.Carbon::now()->timestamp.':F>
 
-If you would like to begin training again, please re-apply via the Gander Website.');
+If you would like to begin training again, please re-apply via the Gander Website.
+
+**Kind Regards,
+Gander Oceanic Training Team**');
+
+                } elseif($status == "terminate"){
+                    $this->sendMessageWithEmbed($thread['id'], 'Oceanic Training Terminated',
+'<@'.$discord_id.'>, Your training request with Gander Oceanic has been terminated at <t:'.Carbon::now()->timestamp.':F>. 
+                    
+This is due to not completing the Exam within 60 Days of your application being accepted.
+                    
+If you would like to begin training again, please re-apply via the Gander Website.
+
+**Kind Regards,
+Gander Oceanic Training Team**');
                 }
 
                 // Lock and Archive the Thread

--- a/app/Services/DiscordClient.php
+++ b/app/Services/DiscordClient.php
@@ -96,6 +96,7 @@ class DiscordClient
         $response = $this->client->post("channels/".env('DISCORD_TRAINING_FORUM')."/threads", [
             'json' => [
                 'name' => $name,
+                'auto_archive_duration' => 20160,
                 'applied_tags' => [1271845980865695774], //Tag ID for 'New Request'
                 'message' => [
                     'content' => $user.', your application has now been approved. Welcome to Gander Oceanic! 

--- a/resources/views/admin/training/instructing/students/student.blade.php
+++ b/resources/views/admin/training/instructing/students/student.blade.php
@@ -58,7 +58,7 @@
             <ul class="list-unstyled mt-2">
                 @can('edit students')
                     <div class="list-group z-depth-1">
-                        <a data-target="#deleteStudentModal" data-toggle="modal" class="list-group-item list-group-item-action red-text"><i class="fas fa-dumpster-fire mr-3"></i>Remove User as Student</a>
+                        <a data-target="#deleteStudentModal" data-toggle="modal" class="list-group-item list-group-item-action red-text"><i class="fas fa-dumpster-fire mr-3"></i>Terminate User as Student</a>
                     </div>
                 @endcan
                 @if($student->user->rosterProfile->certification == "training")

--- a/resources/views/my/index.blade.php
+++ b/resources/views/my/index.blade.php
@@ -411,11 +411,11 @@
                                                     class="waves-effect list-group-item list-group-item-action">
                                                     <i style="margin-right: 10px;" class="fas fa-users fa-fw"></i>Roster
                                                 </a>
-                                                <a href="{{ route('training.admin.solocertifications') }}"
+                                                {{-- <a href="{{ route('training.admin.solocertifications') }}"
                                                     class="waves-effect list-group-item list-group-item-action">
                                                     <i style="margin-right: 10px;" class="fas fa-certificate fa-fw"></i>Solo
                                                     Certifications
-                                                </a>
+                                                </a> --}}
                                             @endcan
                                             @can('view applications')
                                                 <a href="{{ route('training.admin.applications') }}"


### PR DESCRIPTION
- Auto Open & Unlock Training Threads which have passed the 1wk inactivity issue set by discord
- Fixes to Threads not updating `Ready For Pick-Up` or 'In Progress' Status
- Message students without booked session to provide weeks availability.
- Follow up on `Exam-Request` students that have been inactive for 30days.
- Terminate students on `Exam-Request` students that have been inactive for 60days.